### PR TITLE
Added new function to get signature exact status from WinTrust API

### DIFF
--- a/src/PeSignatureVerifier.cpp
+++ b/src/PeSignatureVerifier.cpp
@@ -4,27 +4,26 @@
 
 #define SHA256 L"SHA256"
 
-bool PeSignatureVerifier::VerifySignature(std::wstring aPePath)
+DWORD PeSignatureVerifier::GetSignatureStatus(std::wstring aPePath)
 {
 	// Try to find embeeded signature in the given PE.
 	if (verifyFromFile(aPePath) == ERROR_SUCCESS)
 	{
-		return true;
+		return ERROR_SUCCESS;
 	}
 
-	// Calculate the hash for the given PE and look for in in Windows catalogs.
-	if (verifyFromCatalog(aPePath, SHA256) == ERROR_SUCCESS)
-	{
-		return true;
-	}
+	// Calculate the hash for the given PE and look for in Windows catalogs.
+	return verifyFromCatalog(aPePath, SHA256);
+}
 
-	return false;
+bool PeSignatureVerifier::VerifySignature(std::wstring aPePath)
+{
+	return (GetSignatureStatus(aPePath) == ERROR_SUCCESS);
 }
 
 
 DWORD PeSignatureVerifier::verifyFromFile(std::wstring aPePath)
 {
-	LONG lStatus;
 	GUID WintrustVerifyGuid = WINTRUST_ACTION_GENERIC_VERIFY_V2;
 	GUID DriverActionGuid = DRIVER_ACTION_VERIFY;
 
@@ -53,9 +52,7 @@ DWORD PeSignatureVerifier::verifyFromFile(std::wstring aPePath)
 	wd.pSIPClientData = NULL;
 	wd.dwUIContext = 0;
 
-	lStatus = WinVerifyTrust(NULL, &WintrustVerifyGuid, &wd);
-
-	return lStatus;
+	return WinVerifyTrust(NULL, &WintrustVerifyGuid, &wd);
 }
 
 DWORD PeSignatureVerifier::verifyFromCatalog(

--- a/src/PeSignatureVerifier.h
+++ b/src/PeSignatureVerifier.h
@@ -18,6 +18,11 @@ public:
 	/**
 	* @returns: true iff the PE's signature is verified, false othervise.
 	*/
+	static DWORD GetSignatureStatus(std::wstring aPePath);
+
+	/**
+	* @returns: true iff the PE's signature is verified, false othervise.
+	*/
 	static bool VerifySignature(std::wstring aPePath);
 
 private:

--- a/tests/PeSignatureVerifierTests.cpp
+++ b/tests/PeSignatureVerifierTests.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 #include "./../src/PeSignatureVerifier.h"
 
+#pragma region VerifySignature Tests
 TEST_CASE("Test common Windows system files", "[windows]")
 {
 
@@ -30,7 +31,7 @@ TEST_CASE("Test common Program Files applications", "[ProgramFiles]")
 {
 
 	bool lResult = PeSignatureVerifier::VerifySignature(
-		L"C:\\Program Files\\Mozilla Firefox\\firefox.exe");
+		L"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
 
 	REQUIRE(lResult == true);
 
@@ -52,3 +53,59 @@ TEST_CASE("Try to scan file with invalid name", "[invalid]")
 
 	REQUIRE(lResult == false);
 }
+#pragma endregion
+
+#pragma region GetSignatureStatus Tests
+TEST_CASE("GetSignatureStatus:Test common Windows system files", "[windows]")
+{
+
+	DWORD lResult = PeSignatureVerifier::GetSignatureStatus(
+		L"C:\\Windows\\explorer.exe");
+
+	REQUIRE(lResult == ERROR_SUCCESS);
+
+	lResult = PeSignatureVerifier::GetSignatureStatus(
+		L"C:\\Windows\\System32\\msi.dll");
+
+	REQUIRE(lResult == ERROR_SUCCESS);
+
+	lResult = PeSignatureVerifier::GetSignatureStatus(
+		L"C:\\Windows\\System32\\Defrag.exe");
+
+	REQUIRE(lResult == ERROR_SUCCESS);
+
+	lResult = PeSignatureVerifier::GetSignatureStatus(
+		L"C:\\Windows\\System32\\calc.exe");
+
+	REQUIRE(lResult == ERROR_SUCCESS);
+}
+
+TEST_CASE("GetSignatureStatus:Test common Program Files applications", "[ProgramFiles]")
+{
+
+	DWORD lResult = PeSignatureVerifier::GetSignatureStatus(
+		L"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
+
+	REQUIRE(lResult == ERROR_SUCCESS);
+
+}
+
+TEST_CASE("GetSignatureStatus:Try to check if current running exe is signed", "[GetModuleFileName]")
+{
+	wchar_t lCurrentExePath[MAX_PATH];
+	GetModuleFileName(NULL, lCurrentExePath, MAX_PATH);
+
+	DWORD lResult = PeSignatureVerifier::GetSignatureStatus(lCurrentExePath);
+	printf("result: %d\n",lResult);
+
+	REQUIRE(lResult != ERROR_SUCCESS);
+}
+
+TEST_CASE("GetSignatureStatus:Try to scan file with invalid name", "[invalid]")
+{
+	DWORD lResult = PeSignatureVerifier::GetSignatureStatus(L"INVALID_FILE_NAME");
+	printf("result: %d\n", lResult);
+
+	REQUIRE(lResult != ERROR_SUCCESS);
+}
+#pragma endregion


### PR DESCRIPTION
Kept the existing logic but return the actual status code from verifyfromCatalog function